### PR TITLE
MRADEV-742 Add Kubernetes For Router-mesh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM php:7.0.5-fpm
 ARG CONTAINER_ENGINE_ARG
 ARG USE_NGINX_PLUS_ARG
 ARG USE_VAULT_ARG
+ARG NETWORK_ARG
 
 # CONTAINER_ENGINE specifies the container engine to which the
 # containers will be deployed. Valid values are:
@@ -12,7 +13,8 @@ ARG USE_VAULT_ARG
 ENV USE_NGINX_PLUS=${USE_NGINX_PLUS_ARG:-true} \
     USE_VAULT=${USE_VAULT_ARG:-false} \
     SYMFONY_ENV=prod \
-    CONTAINER_ENGINE=${CONTAINER_ENGINE_ARG:-kubernetes}
+    CONTAINER_ENGINE=${CONTAINER_ENGINE_ARG:-kubernetes} \
+    NETWORK=${NETWORK_ARG:-fabric}
 
 COPY nginx/ssl /etc/ssl/nginx/
 

--- a/install-nginx.sh
+++ b/install-nginx.sh
@@ -20,7 +20,10 @@ then
             ;;
     esac
 else
-    CONFIG_FILE=/etc/nginx/router_config_local.yaml
+    GENERATE_CONFIG_FILE=/usr/local/bin/generate_config_router_mesh
+    TEMPLATE_FILE_PLUS=/etc/nginx/nginx-plus-router-mesh.conf.j2
+    TEMPLATE_FILE=/etc/nginx/nginx-router-mesh.conf.j2
+    CONFIG_FILE=/etc/nginx/router-mesh_config.yaml
 fi
 
 if [ "$USE_VAULT" = true ]; then

--- a/install-nginx.sh
+++ b/install-nginx.sh
@@ -5,6 +5,11 @@ chmod +x /usr/local/sbin/generate_config
 
 GENERATE_CONFIG_FILE=/usr/local/sbin/generate_config
 
+# Default to router-mesh to limit variable creation
+TEMPLATE_FILE_PLUS=/etc/nginx/nginx-plus-router-mesh.conf.j2
+TEMPLATE_FILE=/etc/nginx/nginx-router.conf.j2
+CONFIG_FILE=/etc/nginx/router-mesh_config.yaml
+
 echo -e "\033[32m -----"
 echo -e "\033[32m Building for ${CONTAINER_ENGINE}"
 echo -e "\033[32m -----\033[0m"
@@ -23,10 +28,6 @@ then
             CONFIG_FILE=/etc/nginx/fabric_config_local.yaml
             ;;
     esac
-else
-    TEMPLATE_FILE_PLUS=/etc/nginx/nginx-plus-router-mesh.conf.j2
-    TEMPLATE_FILE=/etc/nginx/nginx-router.conf.j2
-    CONFIG_FILE=/etc/nginx/router-mesh_config.yaml
 fi
 
 if [ "$USE_VAULT" = true ]; then

--- a/nginx/nginx-plus-router-mesh.conf.j2
+++ b/nginx/nginx-plus-router-mesh.conf.j2
@@ -1,0 +1,68 @@
+{% if log_to_syslog %}
+error_log {{ syslog_error_log_location }};
+{% else %}
+error_log {{ error_log_location }};
+{% endif %}
+
+worker_processes  auto;
+
+events {
+  worker_connections  1024;
+}
+
+daemon off;
+
+http {
+
+  include mime.types;
+  include nginx-gz.conf;
+
+  client_max_body_size 30M;
+
+    {% if log_to_syslog %}
+        log_format json '{"service_name": "{{ service_log_name }}",'
+             '"time": "$time_iso8601", '
+             '"remote_addr": "$remote_addr", '
+             '"remote_user": "$remote_user", '
+             '"body_bytes_sent": $body_bytes_sent, '
+             '"request_time": $request_time, '
+             '"status": $status, '
+             '"request": "$request", '
+             '"request_method": "$request_method", '
+             '"http_referrer": "$http_referer", '
+             '"http_x_forwarded_for": "$http_x_forwarded_for", '
+             '"http_user_agent": "$http_user_agent"}';
+    {% else %}
+        log_format main {{ service_log_name }} '$remote_addr - $remote_user [$time_local] "$request" '
+              '$status $body_bytes_sent "$http_referer" '
+              '"$http_user_agent" "$http_x_forwarded_for"';
+    {% endif %}
+
+    {% if log_to_syslog %}
+        access_log {{ syslog_access_log_location }};
+    {% else %}
+        access_log {{ access_log_location }};
+    {% endif %}
+
+  server {
+    listen       80;
+
+    keepalive_timeout	3600s;
+    keepalive_disable	none;
+    keepalive_requests  100000;
+
+    server_name {{ name }};
+
+    root {{ root }};
+
+    include default-location.conf;
+
+    location = /status.html {
+      root /usr/share/nginx/html/;
+    }
+
+    location /status {
+      status;
+    }
+  }
+}

--- a/nginx/nginx-plus-router-mesh.conf.j2
+++ b/nginx/nginx-plus-router-mesh.conf.j2
@@ -61,8 +61,10 @@ http {
       root /usr/share/nginx/html/;
     }
 
-    location /status {
-      status;
+    location /api {
+      api write=on;
+      allow 127.0.0.1;
+      deny  all;
     }
   }
 }

--- a/nginx/router-mesh_config.yaml
+++ b/nginx/router-mesh_config.yaml
@@ -3,17 +3,12 @@ resolver:
   host: 127.0.0.11
   ttl: 1s
 root: /ingenious-pages/web
+external_domain_name:
+internal_domain_name:
+namespace:
 log_to_syslog : false
 syslog_error_log_location: "syslog:server=localhost:5544 debug"
 error_log_location: "/var/log/nginx/error_log debug"
 service_log_name: pages_mra
 syslog_access_log_location: "syslog:server=localhost:5544,facility=local6,tag=pages_mra,severity=info json"
 access_log_location: "/var/log/nginx/access_log combined"
-namespace:
-internal_domain_name:
-services:
-# the server attribute is required for every service in order to
-# populate the nginx.conf template. the format is:
-# <server-name>:<server-port>
-  placeholder:
-    server: 'placeholder'


### PR DESCRIPTION
Add support for Kubernetes with router-mesh, including a new network variable "NETWORK_ARG" That should be included in docker-compose files that specifies which configuration to use.