### PR TITLE
Escape key doesn’t close album images and sends user back to home page

### DIFF
--- a/ingenious-pages/app/Resources/views/nav_header.html.twig
+++ b/ingenious-pages/app/Resources/views/nav_header.html.twig
@@ -162,7 +162,8 @@
                                             <option data-poster-photo="{{ album.poster_image.medium_url }}" value={{ album.id }}>{{ album.name }}</option>
                                         {% endif %}
                                     {% endfor %}
-                                {% endif %}                            </select>
+                                {% endif %}
+                            </select>
                         </div>
                     </div>
                 </div>

--- a/ingenious-pages/app/Resources/views/nav_header.html.twig
+++ b/ingenious-pages/app/Resources/views/nav_header.html.twig
@@ -156,13 +156,13 @@
                                 <option value="undefined">---</option>
                                 {% if catalog is defined %}
                                     {% for album in catalog|reverse %}
-                                        {% if album.id != profilePicturesID and album.id != coverPicturesID and album.state == 'active' and not album.public%}
-                                            {# the 'not album.public' keeps posted albums from being deleted #}
-                                            <option value="{{ album.id }}">{{ album.name }}</option>
+                                        {% if album.public %}{# this keeps posted albums from being used twice #}
+                                            <option disabled data-poster-photo="{{ album.poster_image.medium_url }}" value={{ album.id }}>{{ album.name }} -- Posted: can't delete </option>
+                                        {% else %}
+                                            <option data-poster-photo="{{ album.poster_image.medium_url }}" value={{ album.id }}>{{ album.name }}</option>
                                         {% endif %}
                                     {% endfor %}
-                                {% endif %}
-                            </select>
+                                {% endif %}                            </select>
                         </div>
                     </div>
                 </div>

--- a/ingenious-pages/app/Resources/views/post-article.html.twig
+++ b/ingenious-pages/app/Resources/views/post-article.html.twig
@@ -43,9 +43,14 @@
                                 </div>
                             </div>
                             {% endblock %}
+                            <script>
+                                $(document).keyup(function(e) {
+                                    if (e.keyCode === 27) window.location.replace("/#{{ article.id }}");   // esc
+                                });
+                            </script>
                             <div class="back-to-home">
                                 <a href="/#{{ article.id }}">Back to Home</a>
-                            </div> '>
+                            </div>'>
                             <!--./lightbox content for each photo ****NOTE THE '> AT THE END OF THE data-sub-html element****-->
 
                                 <div class="col-sm-2 col-xs-4 post-photo-thumb photo-thumb">

--- a/ingenious-pages/web/bundles/ingenious/js/main.js
+++ b/ingenious-pages/web/bundles/ingenious/js/main.js
@@ -80,7 +80,8 @@
             mode: 'lg-fade',
             cssEasing: 'cubic-bezier(0.25, 0, 0.25, 1)',
             counter: false,
-            download: false
+            download: false,
+            escKey: false
         });
         $(".post-photo-thumb:first").click();
         // Had to do the click approach because the documented way of


### PR DESCRIPTION
Fixes escape key behavior in posted albums so that it doesn't close the image gallery
Escape key now goes back to home page
Delete album menu now shows public albums but they are unselectable and say they are posted